### PR TITLE
Removing SupportPartialMgDiscovery from settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -32,7 +32,6 @@
             "Core.SkipRole": false,
             "Core.State": "",
             "Core.SubscriptionsToIncludeResourceGroups": "*",
-            "Core.SupportPartialMgDiscovery": false,
             "Core.TemplateParameterFileSuffix": ".json",
             "Core.ThrottleLimit": 10
         },


### PR DESCRIPTION
Setting no longer needed as per https://github.com/Azure/AzOps/pull/310