### PR TITLE
Added sample of AzOps pinning

### DIFF
--- a/.pipelines/samples/Multiple-Environment/templates/AzOpsInstall.yml
+++ b/.pipelines/samples/Multiple-Environment/templates/AzOpsInstall.yml
@@ -1,9 +1,24 @@
 steps:
 - task: PowerShell@2
-  displayName: "Install AzOps and Dependencies"
+  displayName: "Install (Edge) AzOps"
+  condition: or(eq(variables['AzOpsVersion'], ''), eq(variables['AzOpsVersion'], 'edge'))
   inputs:
     targetType: "inline"
     script: |
-      Install-Module -Name AzOps -AllowPrerelease -Force
+      Write-Output "Installing latest AzOps Version"
+
+      Install-Module -Name AzOps -Force
+      
+      Get-InstalledModule | select Name, Version, Repository, InstalledDate | ft
+
+- task: PowerShell@2
+  displayName: "Install (Pinned) AzOps"
+  condition: ne(variables['AzOpsVersion'], '')
+  inputs:
+    targetType: "inline"
+    script: |
+      Write-Output "Installing AzOps Version $(AzOpsVersion)"
+
+      Install-Module -Name AzOps -RequiredVersion $(AzOpsVersion) -Force
       
       Get-InstalledModule | select Name, Version, Repository, InstalledDate | ft


### PR DESCRIPTION
Uses an optional variable that can be set in the variable group or pipeline itself in order to neatly "pin" the installation of AzOps.
The default behaviour is still to install the latest.

It can simply be overridden when testing new pipelines by using a new task to overwrite the value for that specific run;
```
      - bash: echo "##vso[task.setvariable variable=AzOpsVersion;]edge"
```