### PR TITLE
SkipResourceType

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -26,6 +26,11 @@
             "Core.SkipPolicy": false,
             "Core.SkipResource": true,
             "Core.SkipResourceGroup": false,
+            "Core.SkipResourceType": [
+                "Microsoft.PowerPlatform/accounts",
+                "Microsoft.PowerPlatform/enterprisePolicies",
+                "Microsoft.VSOnline/plans"
+            ],
             "Core.SkipRole": false,
             "Core.SubscriptionsToIncludeResourceGroups": "*",
             "Core.TemplateParameterFileSuffix": ".json",


### PR DESCRIPTION
Adds the exclude/skip resource types setting at rg scope that should not or cant be synced.
By default it excludes/skips: 'Microsoft.VSOnline/plans','Microsoft.PowerPlatform/accounts','Microsoft.PowerPlatform/enterprisePolicies'

Relates to Azure/AzOps#427
Relates to Azure/AzOps#466