### PR TITLE
Adding default setting suggestion for excluding whatif output types.

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -36,7 +36,11 @@
             "Core.SkipRole": false,
             "Core.SubscriptionsToIncludeResourceGroups": "*",
             "Core.TemplateParameterFileSuffix": ".json",
-            "Core.ThrottleLimit": 10
+            "Core.ThrottleLimit": 10,
+            "Core.WhatifExcludedChangeTypes":[
+                "NoChange",
+                "Ignore"
+            ]
         },
         "|AzureDevOps": {
             "!Condition": "EnvAzDevPipeline",


### PR DESCRIPTION
This complements a change I am proposing in Az Ops here https://github.com/Azure/AzOps/pull/482