### PR TITLE
Add caching to Azure Pipelines

### DIFF
--- a/.pipelines/pull.yml
+++ b/.pipelines/pull.yml
@@ -323,14 +323,24 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
-            az repos pr create \
+            # Open new PR
+            PROut=$(
+              az repos pr create \
               --title "$(pull_request)" \
               --source-branch "$(branch)" \
               --target-branch "main" \
               --squash true \
               --delete-source-branch true \
               --auto-complete true \
-              --bypass-policy true \
-              --bypass-policy-reason "Automated pull request"
+            );
+
+            # Get PR ID and check status
+            PRid=$(echo $PROut | jq -r '.pullRequestId');
+            PRStatus=$(az repos pr show --id $PRid --organization "https://dev.azure.com/advaniase" | jq .status);
+
+            # If PR is not completed, then complete it bypassing policy
+            if [ $PRStatus == "\"active\"" ]; then
+              az repos pr update --status completed --id $PRid --bypass-policy true --bypass-policy-reason "Automated pull request" --organization "https://dev.azure.com/advaniase" > /dev/null 2>&1
+            fi;
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)

--- a/.pipelines/pull.yml
+++ b/.pipelines/pull.yml
@@ -169,6 +169,22 @@ jobs:
             git checkout -b $(branch)
 
       #
+      # Get Latest AzOps version
+      # Query PowerShell Gallery for the latest AzOps version
+      # to be used as cache key if no version is specified
+      #
+
+      - task: PowerShell@2
+        displayName: "Get Latest AzOps version"
+        condition: eq(variables['AZOPS_MODULE_VERSION'], '')
+        inputs:
+          targetType: "inline"
+          script: |
+            $latestVersionUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzOps'&`$filter=IsLatestVersion"
+            $latestVersionId = (Invoke-RestMethod $latestVersionUri).properties.NormalizedVersion
+            Write-Host "##vso[task.setvariable variable=AZOPS_MODULE_VERSION;]$latestVersionId"
+
+      #
       # Cache Dependencies
       # Cache dependencies if version has not changed
       #

--- a/.pipelines/pull.yml
+++ b/.pipelines/pull.yml
@@ -47,14 +47,27 @@ variables:
   # Credentials
   # This reference is to the Variable Group which needs
   # to be created which will contain the following values.
+  # Set AZOPS_MODULE_VERSION to the desired version of the 
+  # AzOps Module to enable version pinning and caching.
   #
   # - ARM_TENANT_ID
   # - ARM_SUBSCRIPTION_ID
   # - ARM_CLIENT_ID
   # - ARM_CLIENT_SECRET
+  # - AZOPS_MODULE_VERSION   
   #
 
   - group: credentials
+
+  #
+  # modulesFolder
+  # To enable caching of PowerShell modules between
+  # runs, the modules are stored in a modules folder
+  # that can be cached.
+  #
+
+  - name: modulesFolder
+    value: '$(System.DefaultWorkingDirectory)/Modules'
 
   #
   # Folder Name
@@ -156,16 +169,42 @@ jobs:
             git checkout -b $(branch)
 
       #
+      # Cache Dependencies
+      # Cache dependencies if version has not changed
+      #
+
+      - task: Cache@2
+        displayName: Cache AzOps module
+        condition: ne(variables['AZOPS_MODULE_VERSION'], '')
+        # This task will restore modules from cache if key is found.
+        inputs:
+          key:  '"AzOpsModule" | "$(AZOPS_MODULE_VERSION)"'
+          path: $(modulesFolder)
+          cacheHitVar: AzOpsModule_IsCached
+
+      #
       # Dependencies
       # Install required runtime modules
       #
 
       - task: PowerShell@2
         displayName: "Dependencies"
+        condition: or(eq(variables['AZOPS_MODULE_VERSION'], ''), ne(variables['AzOpsModule_IsCached'], 'true'))
         inputs:
           targetType: "inline"
           script: |
-            Install-Module -Name AzOps -Force
+            if(-not (Test-Path -Path '$(modulesFolder)')) {
+              mkdir '$(modulesFolder)'
+            }
+            $params = @{
+              Name            = 'AzOps'
+              Path            = '$(modulesFolder)'
+              Force           = $true
+            }
+            if('$(AZOPS_MODULE_VERSION)') {
+              $params.RequiredVersion = '$(AZOPS_MODULE_VERSION)'
+            }
+            Save-Module @params
 
       #
       # Connect
@@ -177,6 +216,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
+            $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
             $credential = New-Object PSCredential -ArgumentList $(ARM_CLIENT_ID), (ConvertTo-SecureString -String $(ARM_CLIENT_SECRET) -AsPlainText -Force)
             Connect-AzAccount -TenantId $(ARM_TENANT_ID) -ServicePrincipal -Credential $credential -SubscriptionId $(ARM_SUBSCRIPTION_ID)
 
@@ -190,6 +230,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
+            $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
             Import-PSFConfig -Path settings.json -Schema MetaJson -EnableException
             Invoke-AzOpsPull -Rebuild
             Get-Job | Remove-Job -Force
@@ -204,7 +245,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
-            STATUS=$(git status --short)
+            STATUS=$(git status --short $(folder))
             echo $STATUS
             if [ -z "$STATUS" ]
             then
@@ -272,6 +313,8 @@ jobs:
               --target-branch "main" \
               --squash true \
               --delete-source-branch true \
-              --auto-complete true
+              --auto-complete true \
+              --bypass-policy true \
+              --bypass-policy-reason "Automated pull request"
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)

--- a/.pipelines/push.yml
+++ b/.pipelines/push.yml
@@ -22,14 +22,27 @@ variables:
   # Credentials
   # This reference is to the Variable Group which needs
   # to be created which will contain the following values.
+  # Set AZOPS_MODULE_VERSION to the desired version of the 
+  # AzOps Module to enable version pinning and caching.
   #
   # - ARM_TENANT_ID
   # - ARM_SUBSCRIPTION_ID
   # - ARM_CLIENT_ID
   # - ARM_CLIENT_SECRET
+  # - AZOPS_MODULE_VERSION   
   #
 
   - group: credentials
+
+  #
+  # modulesFolder
+  # To enable caching of PowerShell modules between
+  # runs, the modules are stored in a modules folder
+  # that can be cached.
+  #
+
+  - name: modulesFolder
+    value: '$(System.DefaultWorkingDirectory)/Modules'
 
 jobs:
 
@@ -58,16 +71,42 @@ jobs:
         persistCredentials: true
 
       #
+      # Cache Dependencies
+      # Cache dependencies if version has not changed
+      #
+
+      - task: Cache@2
+        displayName: Cache AzOps module
+        condition: ne(variables['AZOPS_MODULE_VERSION'], '')
+        # This task will restore modules from cache if key is found.
+        inputs:
+          key:  '"AzOpsModule" | "$(AZOPS_MODULE_VERSION)"'
+          path: $(modulesFolder)
+          cacheHitVar: AzOpsModule_IsCached
+
+      #
       # Dependencies
       # Install required runtime modules
       #
 
       - task: PowerShell@2
         displayName: "Dependencies"
+        condition: or(eq(variables['AZOPS_MODULE_VERSION'], ''), ne(variables['AzOpsModule_IsCached'], 'true'))
         inputs:
           targetType: "inline"
           script: |
-            Install-Module -Name AzOps -Force
+            if(-not (Test-Path -Path '$(modulesFolder)')) {
+              mkdir '$(modulesFolder)'
+            }
+            $params = @{
+              Name            = 'AzOps'
+              Path            = '$(modulesFolder)'
+              Force           = $true
+            }
+            if('$(AZOPS_MODULE_VERSION)') {
+              $params.RequiredVersion = '$(AZOPS_MODULE_VERSION)'
+            }
+            Save-Module @params
 
       #
       # Connect
@@ -79,6 +118,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
+            $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
             $credential = New-Object PSCredential -ArgumentList $(ARM_CLIENT_ID), (ConvertTo-SecureString -String $(ARM_CLIENT_SECRET) -AsPlainText -Force)
             Connect-AzAccount -TenantId $(ARM_TENANT_ID) -ServicePrincipal -Credential $credential -SubscriptionId $(ARM_SUBSCRIPTION_ID)
 
@@ -114,6 +154,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
+            $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
             Import-PSFConfig -Path settings.json -Schema MetaJson -EnableException
             Initialize-AzOpsEnvironment
             $diff = Get-Content -Path /tmp/diff.txt

--- a/.pipelines/push.yml
+++ b/.pipelines/push.yml
@@ -71,6 +71,22 @@ jobs:
         persistCredentials: true
 
       #
+      # Get Latest AzOps version
+      # Query PowerShell Gallery for the latest AzOps version
+      # to be used as cache key if no version is specified
+      #
+
+      - task: PowerShell@2
+        displayName: "Get Latest AzOps version"
+        condition: eq(variables['AZOPS_MODULE_VERSION'], '')
+        inputs:
+          targetType: "inline"
+          script: |
+            $latestVersionUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzOps'&`$filter=IsLatestVersion"
+            $latestVersionId = (Invoke-RestMethod $latestVersionUri).properties.NormalizedVersion
+            Write-Host "##vso[task.setvariable variable=AZOPS_MODULE_VERSION;]$latestVersionId"
+
+      #
       # Cache Dependencies
       # Cache dependencies if version has not changed
       #

--- a/.pipelines/validate.yml
+++ b/.pipelines/validate.yml
@@ -16,14 +16,27 @@ variables:
   # Credentials
   # This reference is to the Variable Group which needs
   # to be created which will contain the following values.
+  # Set AZOPS_MODULE_VERSION to the desired version of the 
+  # AzOps Module to enable version pinning and caching.
   #
   # - ARM_TENANT_ID
   # - ARM_SUBSCRIPTION_ID
   # - ARM_CLIENT_ID
   # - ARM_CLIENT_SECRET
+  # - AZOPS_MODULE_VERSION   
   #
 
   - group: credentials
+
+  #
+  # modulesFolder
+  # To enable caching of PowerShell modules between
+  # runs, the modules are stored in a modules folder
+  # that can be cached.
+  #
+
+  - name: modulesFolder
+    value: '$(System.DefaultWorkingDirectory)/Modules'
 
 jobs:
 
@@ -49,16 +62,42 @@ jobs:
         persistCredentials: true
 
       #
+      # Cache Dependencies
+      # Cache dependencies if version has not changed
+      #
+
+      - task: Cache@2
+        displayName: Cache AzOps module
+        condition: ne(variables['AZOPS_MODULE_VERSION'], '')
+        # This task will restore modules from cache if key is found.
+        inputs:
+          key:  '"AzOpsModule" | "$(AZOPS_MODULE_VERSION)"'
+          path: $(modulesFolder)
+          cacheHitVar: AzOpsModule_IsCached
+      
+      #
       # Dependencies
       # Install required runtime modules
       #
 
       - task: PowerShell@2
         displayName: "Dependencies"
+        condition: or(eq(variables['AZOPS_MODULE_VERSION'], ''), ne(variables['AzOpsModule_IsCached'], 'true'))
         inputs:
           targetType: "inline"
           script: |
-            Install-Module -Name "AzOps" -Force
+            if(-not (Test-Path -Path '$(modulesFolder)')) {
+              mkdir '$(modulesFolder)'
+            }
+            $params = @{
+              Name            = 'AzOps'
+              Path            = '$(modulesFolder)'
+              Force           = $true
+            }
+            if('$(AZOPS_MODULE_VERSION)') {
+              $params.RequiredVersion = '$(AZOPS_MODULE_VERSION)'
+            }
+            Save-Module @params
 
       #
       # Connect
@@ -70,6 +109,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
+            $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
             $credential = New-Object PSCredential -ArgumentList $(ARM_CLIENT_ID), (ConvertTo-SecureString -String $(ARM_CLIENT_SECRET) -AsPlainText -Force)
             Connect-AzAccount -TenantId $(ARM_TENANT_ID) -ServicePrincipal -Credential $credential -SubscriptionId $(ARM_SUBSCRIPTION_ID)
 
@@ -104,6 +144,7 @@ jobs:
         inputs:
           targetType: "inline"
           script: |
+            $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
             Import-PSFConfig -Path settings.json -Schema MetaJson -EnableException
             Initialize-AzOpsEnvironment
             $diff = Get-Content -Path /tmp/diff.txt

--- a/.pipelines/validate.yml
+++ b/.pipelines/validate.yml
@@ -62,6 +62,22 @@ jobs:
         persistCredentials: true
 
       #
+      # Get Latest AzOps version
+      # Query PowerShell Gallery for the latest AzOps version
+      # to be used as cache key if no version is specified
+      #
+
+      - task: PowerShell@2
+        displayName: "Get Latest AzOps version"
+        condition: eq(variables['AZOPS_MODULE_VERSION'], '')
+        inputs:
+          targetType: "inline"
+          script: |
+            $latestVersionUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzOps'&`$filter=IsLatestVersion"
+            $latestVersionId = (Invoke-RestMethod $latestVersionUri).properties.NormalizedVersion
+            Write-Host "##vso[task.setvariable variable=AZOPS_MODULE_VERSION;]$latestVersionId"
+
+      #
       # Cache Dependencies
       # Cache dependencies if version has not changed
       #


### PR DESCRIPTION
This is a suggestion on how we can add caching to the Azure DevOps pipelines as suggested in https://github.com/Azure/AzOps/issues/383.

I've chosen to add the setting AZOPS_MODULE_VERSION to the variable group credentials where a user can choose to set a version of AzOps module to use. I chose to use the variable group instead of having a variable in each pipeline to not have to update all pipelines to change the module version. The value of this variable will be used as a cache key, meaning that the module dependencies will only be downloaded once per pipeline and then be cached, saving almost 2 minutes on each run.

To make caching possible I'm saving the modules to a folder that can be cached. The folder path is specified in variable modulesFolder. Since PowerShell won't automatically load modules in the modulesFolder I'm appending modulesFolder path to $Env:PSModulePath in each task that loads the AzOps module. If anyone has a better way of modifying PSModulePath I'd be very grateful!

Last I also added the parameters to bypass branch policies for the PR from PULL pipeline to work around the fact that we always use branch policies with required approvals on main branch.