### PR TITLE
Azure Pipelines - fix 'update' pipeline that silently fails after creating empty PR

### DIFF
--- a/.pipelines/update.yml
+++ b/.pipelines/update.yml
@@ -102,7 +102,7 @@ jobs:
           workingDirectory: ".."
           script: |
             test -f ./origin/.pipelines/patch.yml && rm -f ./origin/.pipelines/patch.yml
-            cp -R ./upstream/.pipelines/* ./origin/.pipelines/
+            cp -R -v ./upstream/.pipelines/ ./origin/
 
       #
       # Commit

--- a/.pipelines/update.yml
+++ b/.pipelines/update.yml
@@ -119,10 +119,10 @@ jobs:
             echo $DIFF
             if [ -n "$DIFF" ]
             then
-              git checkout -b $(branch)
+              git checkout -b "$(branch)"
               git add .pipelines/
-              git commit -m $(commit)
-              git push origin $(branch) -f
+              git commit -m "$(commit)"
+              git push origin "$(branch)" -f
               echo "##vso[task.setvariable variable=state]continue"
             fi
 


### PR DESCRIPTION
This PR makes two minor adjustments to the 'update' pipeline in the Azure Pipelines implementation.

I recently tried to use the 'update' pipeline to apply upstream updates to my local pipelines but failed for two reasons:
1. the default commit message needs to be surrounded by quotes when expanded as it contains a space
2. the newly introduced shared steps in #103 added a .templates folder that is not included from upstream causing the local pipeline definitions to be invalid

Without quotes (1) the default commit message generates output like this - and an empty PR gets created - but without failing the pipeline run it seems:

```
...
.pipelines/pull.yml .pipelines/push.yml .pipelines/samples/Multiple-Environment/multienv/canary-pull.yml .pipelines/samples/Multiple-Environment/multienv/canary-push.yml .pipelines/samples/Multiple-Environment/multienv/prod-pull.yml .pipelines/samples/Multiple-Environment/multienv/prod-push.yml .pipelines/samples/Multiple-Environment/templates/AzOpsInstall.yml .pipelines/samples/Multiple-Environment/templates/AzureLoginWithSp.yml .pipelines/samples/Multiple-Environment/templates/AzureLoginWithSpJson.yml .pipelines/samples/Multiple-Environment/templates/GitCreateDiff.yml .pipelines/samples/Multiple-Environment/templates/GitCreatePullPR.yml .pipelines/samples/README.md .pipelines/validate.yml
Switched to a new branch 'update'
error: pathspec 'commit' did not match any file(s) known to git
Everything up-to-date

```

