### PR TITLE
Remove parameters from pipeline templates

### DIFF
--- a/.pipelines/.templates/sharedSteps.yml
+++ b/.pipelines/.templates/sharedSteps.yml
@@ -1,31 +1,3 @@
-parameters:
-
-  - name: AZOPS_MODULE_VERSION
-    type: string
-    default: ''
-
-  - name: modulesFolder
-    type: string
-    default: '$(System.DefaultWorkingDirectory)/Modules'
-
-  - name: ARM_CLIENT_ID
-    type: string
-    default: ''
-
-  - name: ARM_CLIENT_SECRET
-    type: string
-    default: ''
-
-  - name: ARM_ENVIRONMENT
-    type: string
-    default: ''
-
-  - name: ARM_SUBSCRIPTION_ID
-    type: string
-
-  - name: ARM_TENANT_ID
-    type: string
-
 steps:
 
   #

--- a/.pipelines/.templates/validate-deploy.yml
+++ b/.pipelines/.templates/validate-deploy.yml
@@ -3,10 +3,6 @@ parameters:
     type: boolean
     default: false
 
-  - name: modulesFolder
-    type: string
-    default: '$(System.DefaultWorkingDirectory)/Modules'
-
 steps:
 
     #

--- a/.pipelines/.templates/vars.yml
+++ b/.pipelines/.templates/vars.yml
@@ -6,7 +6,7 @@ variables:
   # to be created which will contain the following values.
   #
   # Set ARM_ENVIRONMENT to the Azure Environment you wish to use.
-  # Valid values are: AzureCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernment
+  # Valid values are: AzureCloud, AzureChinaCloud, AzureUSGovernment
   #
   # Set AZOPS_MODULE_VERSION to the desired version of the 
   # AzOps Module to enable version pinning. No value will cache the latest release.

--- a/.pipelines/.templates/vars.yml
+++ b/.pipelines/.templates/vars.yml
@@ -4,13 +4,18 @@ variables:
   # Credentials
   # This reference is to the Variable Group which needs
   # to be created which will contain the following values.
+  #
+  # Set ARM_ENVIRONMENT to the Azure Environment you wish to use.
+  # Valid values are: AzureCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernment
+  #
   # Set AZOPS_MODULE_VERSION to the desired version of the 
-  # AzOps Module to enable version pinning and caching.
+  # AzOps Module to enable version pinning. No value will cache the latest release.
   #
   # - ARM_TENANT_ID
   # - ARM_SUBSCRIPTION_ID
   # - ARM_CLIENT_ID
   # - ARM_CLIENT_SECRET
+  # - ARM_ENVIRONMENT
   # - AZOPS_MODULE_VERSION   
   #
 

--- a/.pipelines/pull.yml
+++ b/.pipelines/pull.yml
@@ -123,14 +123,6 @@ jobs:
       #
       
       - template: .templates/sharedSteps.yml
-        parameters:
-          AZOPS_MODULE_VERSION: ${{ variables['AZOPS_MODULE_VERSION'] }}
-          modulesFolder: ${{ variables['modulesFolder'] }}
-          ARM_CLIENT_ID: ${{ variables['ARM_CLIENT_ID'] }}
-          ARM_CLIENT_SECRET: ${{ variables['ARM_CLIENT_SECRET'] }}
-          ARM_ENVIRONMENT: ${{ variables['ARM_ENVIRONMENT'] }}
-          ARM_SUBSCRIPTION_ID: ${{ variables['ARM_SUBSCRIPTION_ID'] }}
-          ARM_TENANT_ID: ${{ variables['ARM_TENANT_ID'] }}
 
       #
       # Configure

--- a/.pipelines/push.yml
+++ b/.pipelines/push.yml
@@ -50,14 +50,6 @@ jobs:
       #
 
       - template: .templates/sharedSteps.yml
-        parameters:
-          AZOPS_MODULE_VERSION: ${{ variables['AZOPS_MODULE_VERSION'] }}
-          modulesFolder: ${{ variables['modulesFolder'] }}
-          ARM_CLIENT_ID: ${{ variables['ARM_CLIENT_ID'] }}
-          ARM_CLIENT_SECRET: ${{ variables['ARM_CLIENT_SECRET'] }}
-          ARM_ENVIRONMENT: ${{ variables['ARM_ENVIRONMENT'] }}
-          ARM_SUBSCRIPTION_ID: ${{ variables['ARM_SUBSCRIPTION_ID'] }}
-          ARM_TENANT_ID: ${{ variables['ARM_TENANT_ID'] }}
 
       #
       # Deploy
@@ -67,4 +59,3 @@ jobs:
       - template: .templates/validate-deploy.yml
         parameters:
           deploy: true
-          modulesFolder: ${{ variables['modulesFolder'] }}

--- a/.pipelines/validate.yml
+++ b/.pipelines/validate.yml
@@ -41,14 +41,6 @@ jobs:
       #
       
       - template: .templates/sharedSteps.yml
-        parameters:
-          AZOPS_MODULE_VERSION: ${{ variables['AZOPS_MODULE_VERSION'] }}
-          modulesFolder: ${{ variables['modulesFolder'] }}
-          ARM_CLIENT_ID: ${{ variables['ARM_CLIENT_ID'] }}
-          ARM_CLIENT_SECRET: ${{ variables['ARM_CLIENT_SECRET'] }}
-          ARM_ENVIRONMENT: ${{ variables['ARM_ENVIRONMENT'] }}
-          ARM_SUBSCRIPTION_ID: ${{ variables['ARM_SUBSCRIPTION_ID'] }}
-          ARM_TENANT_ID: ${{ variables['ARM_TENANT_ID'] }}
 
       #
       # Validate
@@ -59,7 +51,6 @@ jobs:
       - template: .templates/validate-deploy.yml
         parameters:
           deploy: false
-          modulesFolder: ${{ variables['modulesFolder'] }}
 
       #
       # Results


### PR DESCRIPTION
I've removed parameters from all templates except validate-deploy.yml.

Only relying on variables instead of using parameters makes the templates a bit cleaner and hopefully easier to maintain.