### PR TITLE
Change base reference to `'main'` branch in pull action

### DIFF
--- a/.github/samples/oidc-azuread/pull.yml
+++ b/.github/samples/oidc-azuread/pull.yml
@@ -254,5 +254,5 @@ jobs:
         if: steps.status.outputs.state == 'continue'
         shell: bash
         run: |
-          gh pr create --title "${{ env.pull_request }}" --body "-" --base ${{ github.ref }} --head ${{ env.branch }}
+          gh pr create --title "${{ env.pull_request }}" --body "-" --base 'main' --head ${{ env.branch }}
           gh pr merge "${{ env.branch }}" --squash --delete-branch

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -249,5 +249,5 @@ jobs:
         if: steps.status.outputs.state == 'continue'
         shell: bash
         run: |
-          gh pr create --title "${{ env.pull_request }}" --body "-" --base ${{ github.ref }} --head ${{ env.branch }}
+          gh pr create --title "${{ env.pull_request }}" --body "-" --base 'main' --head ${{ env.branch }}
           gh pr merge "${{ env.branch }}" --squash --delete-branch


### PR DESCRIPTION
Existing --base reference to `${{ github.ref }` are causing the command to fail. Updating to `'main'` as per [documentation](https://cli.github.com/manual/gh_pr_create ). 

Closing issue https://github.com/Azure/AzOps/issues/595 