### PR TITLE
Update - Settings.json three new settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -19,9 +19,12 @@
             ],
             "Core.ExportRawTemplate": false,
             "Core.IgnoreContextCheck": false,
+            "Core.IncludeResourcesInResourceGroup": ["*"],
+            "Core.IncludeResourceType": ["*"],
             "Core.InvalidateCache": true,
             "Core.OfferType": "MS-AZR-0017P",
             "Core.PartialMgDiscoveryRoot": [],
+            "Core.SkipPim": true,
             "Core.SkipPolicy": false,
             "Core.SkipResource": true,
             "Core.SkipChildResource": true,
@@ -34,7 +37,7 @@
                 "Microsoft.VSOnline/plans"
             ],
             "Core.SkipRole": false,
-            "Core.SubscriptionsToIncludeResourceGroups": "*",
+            "Core.SubscriptionsToIncludeResourceGroups": ["*"],
             "Core.TemplateParameterFileSuffix": ".json",
             "Core.ThrottleLimit": 10,
             "Core.WhatifExcludedChangeTypes":[


### PR DESCRIPTION
This PR declares new settings introduced in AzOps 1.8.0
https://github.com/Azure/AzOps/milestone/38

The settings:
`IncludeResourcesInResourceGroup`
`IncludeResourceType`
`SkipPim`

Relates to:
https://github.com/Azure/AzOps/pull/609
https://github.com/Azure/AzOps/pull/635

Read more about the settings at:
https://github.com/azure/azops/wiki/frequently-asked-questions#discovery-scenarios-and-settings
https://github.com/azure/azops/wiki/settings