### PR TITLE
Add support for custom sort order

### DIFF
--- a/.pipelines/.templates/validate-deploy.yml
+++ b/.pipelines/.templates/validate-deploy.yml
@@ -27,6 +27,58 @@ steps:
           exit 1
         fi
 
+    #
+    # CustomSorting
+    # If CustomSorting is enabled, sort files in diff by the .order file in each directory
+    #
+
+  - task: PowerShell@2
+    displayName: "CustomSorting"
+    condition: eq(variables['AZOPS_CUSTOM_SORT_ORDER'],'true')
+    inputs:
+      targetType: "inline"
+      script: |
+        $diff = Get-Content -Path /tmp/diff.txt
+
+        Write-Host '##[section]Files found in diff:'
+        $diff | Write-Host
+
+        $diffTable = @{}
+        $diff | ForEach-Object -Process {
+          $change = $_
+          $path = ($change -split "`t")[-1]
+          $entry = [pscustomobject]@{
+            fileName   = Split-Path -Path $path -Leaf
+            directory  = Split-Path -Path $path -Parent
+            diffString = $change
+          }
+          if ($null -eq $diffTable[$entry.directory]) {
+            $diffTable[$entry.directory] = @{}
+          }
+          if($entry.fileName -ne '.order') {
+            $diffTable[$entry.directory][$entry.fileName] = $entry
+          }
+        }
+
+        $sortedDiff = foreach ($directoryPath in ($diffTable.Keys | Sort-Object)) {
+          $orderPath = Join-Path -Path $directoryPath -ChildPath '.order'
+          if (Test-Path -Path $orderPath) {
+            $order = Get-Content -Path $orderPath | ForEach-Object {$_.Trim()}
+            foreach ($orderName in $order) {
+              if ($null -ne $diffTable.$directoryPath.$orderName) {
+                Write-Output -InputObject $diffTable.$directoryPath.$orderName.diffString
+                $diffTable.$directoryPath.Remove($orderName)
+              }
+            }
+          }
+          Write-Output ($diffTable.$directoryPath.Values.diffString | Sort-Object)
+        }
+
+        Write-Host '##[section]Sorted files:'
+        $sortedDiff | Write-Host
+                
+        $sortedDiff | Out-File -Path '/tmp/diff.txt'
+
   #
   # Validate or Deploy
   # If parameter "deploy" is set to true, then deploy the changes,
@@ -42,15 +94,16 @@ steps:
       targetType: "inline"
       script: |
         $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
+        $CustomSortOrder = $Env:AZOPS_CUSTOM_SORT_ORDER -eq 'true'
         $RunWhatIf = -not ('${{parameters.deploy}}' -eq 'true')
         Import-PSFConfig -Path settings.json -Schema MetaJson -EnableException
         Initialize-AzOpsEnvironment
         $diff = Get-Content -Path /tmp/diff.txt
         if(Test-Path -Path "/tmp/diffdeletedfiles.txt") {
           $diffdeletedfiles = Get-Content -Path /tmp/diffdeletedfiles.txt
-          Invoke-AzOpsPush -ChangeSet $diff -DeleteSetContents $diffdeletedfiles -WhatIf:$RunWhatIf
+          Invoke-AzOpsPush -ChangeSet $diff -DeleteSetContents $diffdeletedfiles -WhatIf:$RunWhatIf -CustomSortOrder:$CustomSortOrder
         } 
         else {
-          Invoke-AzOpsPush -ChangeSet $diff -WhatIf:$RunWhatIf
+          Invoke-AzOpsPush -ChangeSet $diff -WhatIf:$RunWhatIf -CustomSortOrder:$CustomSortOrder
         }
         Get-Job | Remove-Job -Force

--- a/.pipelines/.templates/validate-deploy.yml
+++ b/.pipelines/.templates/validate-deploy.yml
@@ -43,48 +43,8 @@ steps:
     displayName: "CustomSorting"
     condition: eq(variables['AZOPS_CUSTOM_SORT_ORDER'],'true')
     inputs:
-      targetType: "inline"
-      script: |
-        $diff = Get-Content -Path /tmp/diff.txt
-
-        Write-Host '##[section]Files found in diff:'
-        $diff | Write-Host
-
-        $diffTable = @{}
-        $diff | ForEach-Object -Process {
-          $change = $_
-          $path = ($change -split "`t")[-1]
-          $entry = [pscustomobject]@{
-            fileName   = Split-Path -Path $path -Leaf
-            directory  = Split-Path -Path $path -Parent
-            diffString = $change
-          }
-          if ($null -eq $diffTable[$entry.directory]) {
-            $diffTable[$entry.directory] = @{}
-          }
-          if($entry.fileName -ne '.order') {
-            $diffTable[$entry.directory][$entry.fileName] = $entry
-          }
-        }
-
-        $sortedDiff = foreach ($directoryPath in ($diffTable.Keys | Sort-Object)) {
-          $orderPath = Join-Path -Path $directoryPath -ChildPath '.order'
-          if (Test-Path -Path $orderPath) {
-            $order = Get-Content -Path $orderPath | ForEach-Object {$_.Trim()}
-            foreach ($orderName in $order) {
-              if ($null -ne $diffTable.$directoryPath.$orderName) {
-                Write-Output -InputObject $diffTable.$directoryPath.$orderName.diffString
-                $diffTable.$directoryPath.Remove($orderName)
-              }
-            }
-          }
-          Write-Output ($diffTable.$directoryPath.Values.diffString | Sort-Object)
-        }
-
-        Write-Host '##[section]Sorted files:'
-        $sortedDiff | Write-Host
-                
-        $sortedDiff | Out-File -Path '/tmp/diff.txt'
+      targetType: "filePath"
+      filePath: ".scripts/customSorting.ps1"
 
   #
   # Validate or Deploy

--- a/.pipelines/.templates/vars.yml
+++ b/.pipelines/.templates/vars.yml
@@ -11,15 +11,22 @@ variables:
   # Set AZOPS_MODULE_VERSION to the desired version of the 
   # AzOps Module to enable version pinning. No value will cache the latest release.
   #
+  # Set AZOPS_CUSTOM_SORT_ORDER to true to enable custom sorting.
+  # Custom sorting will check for a file named .order in each folder.
+  # Files listed in the .order file will be deployed before other files and in the 
+  # order they are listed.
+  #
   # - ARM_TENANT_ID
   # - ARM_SUBSCRIPTION_ID
   # - ARM_CLIENT_ID
   # - ARM_CLIENT_SECRET
   # - ARM_ENVIRONMENT
   # - AZOPS_MODULE_VERSION   
+  # - AZOPS_CUSTOM_SORT_ORDER 
   #
 
   - group: credentials
+  - group: azops
   
   #
   # modulesFolder

--- a/.scripts/customSorting.ps1
+++ b/.scripts/customSorting.ps1
@@ -1,0 +1,50 @@
+param(
+    $DiffFilePath = '/tmp/diff.txt'
+)
+
+# IF $ENV:CI exists, we assume we are in GitHub, otherwise Azure DevOps
+$StartGroup = $ENV:CI ? '::group::' : '##[group]'
+$EndGroup = $ENV:CI ? '::endgroup::' : '##[endgroup]'
+
+$diff = Get-Content -Path $DiffFilePath
+
+Write-Host "${StartGroup}Files found in diff:"
+
+$diff | Write-Host
+$diffTable = @{}
+$diff | ForEach-Object -Process {
+    $change = $_
+    $path = ($change -split "`t")[-1]
+    $entry = [pscustomobject]@{
+        fileName   = Split-Path -Path $path -Leaf
+        directory  = Split-Path -Path $path -Parent
+        diffString = $change
+    }
+    if ($null -eq $diffTable[$entry.directory]) {
+        $diffTable[$entry.directory] = @{}
+    }
+    if ($entry.fileName -ne '.order') {
+        $diffTable[$entry.directory][$entry.fileName] = $entry
+    }
+}
+$sortedDiff = foreach ($directoryPath in ($diffTable.Keys | Sort-Object)) {
+    $orderPath = Join-Path -Path $directoryPath -ChildPath '.order'
+    if (Test-Path -Path $orderPath) {
+        $order = Get-Content -Path $orderPath | ForEach-Object { $_.Trim() }
+        foreach ($orderName in $order) {
+            if ($null -ne $diffTable.$directoryPath.$orderName) {
+                Write-Output -InputObject $diffTable.$directoryPath.$orderName.diffString
+                $diffTable.$directoryPath.Remove($orderName)
+            }
+        }
+    }
+    Write-Output ($diffTable.$directoryPath.Values.diffString | Sort-Object)
+}
+Write-Host "$EndGroup"
+Write-Host "${StartGroup}Sorted files:"
+
+$sortedDiff | Write-Host
+
+Write-Host "$EndGroup"
+
+$sortedDiff | Out-File -Path $DiffFilePath


### PR DESCRIPTION
# Overview/Summary

Add option to configure in which order templates will be deployed by adding a conditional step between Diff and Validate/Deploy.

I am a bit uncertain on if the variable `AZOPS_CUSTOM_SORT_ORDER` should be put into the credentials variable group or if a new group should be created. If a new group should be created, I am uncertain of what to name it.  
I have considered the following names:  
* azops
* azopsConfig
* config

I do not think it should be named anything related to settings to avoid confusion with settings.json

## This PR fixes/adds/changes/removes

1. Add support for custom sort order of templates

### Breaking Changes

**For Azure DevOps only**: Requires creation of variable group `azops` as well as granting pipelines access to that group.  

## Testing Evidence
CustomSorting step sorts files in diff.txt
![image](https://user-images.githubusercontent.com/5576847/173231681-c9624ad3-b556-48be-823b-a45cb025120c.png)

Deploy step uses parameter -CustomSortOrder and picks up on the order in diff.txt
![image](https://user-images.githubusercontent.com/5576847/173231732-d2a07123-942b-497e-abca-118bdc4a3135.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation. (https://github.com/Azure/AzOps/pull/660)

Fixes Azure/AzOps#592