### PR TITLE
Validate - indicate UTF-8 to avoid null exception when posting WhatIf output as comment to Pull Request

### DIFF
--- a/.pipelines/validate.yml
+++ b/.pipelines/validate.yml
@@ -66,7 +66,7 @@ jobs:
               $uri = "$(System.CollectionUri)/$(System.TeamProject)/_apis/git/repositories/$(Build.Repository.Name)/pullRequests/$(System.PullRequest.PullRequestId)/threads?api-version=6.0"
               Invoke-RestMethod `
                 -Method Post `
-                -Headers @{ "Authorization" = "Bearer $(System.AccessToken)"; "Content-Type" = "application/json" } `
+                -Headers @{ "Authorization" = "Bearer $(System.AccessToken)"; "Content-Type" = "application/json;charset=utf-8" } `
                 -Body (@{
                   "comments" = @(
                       @{ "parentCommentId" = 0; "content" = "$(Get-Content -Path /tmp/OUTPUT.md -Raw)"; "commentType" = 1 }


### PR DESCRIPTION
We stumbled upon some Swedish character in the WhatIf output. This caused the following error:

![image](https://user-images.githubusercontent.com/1163202/185412675-c7d8900d-1121-43e2-bb03-da777db7f1f1.png)

Indicating utf-8 solved the issue. Do you agree?