### PR TITLE
Added initial condition configuration for push pipeline to not incremental redeploy from pull pipeline

### DIFF
--- a/.pipelines/push.yml
+++ b/.pipelines/push.yml
@@ -29,6 +29,7 @@ variables:
 jobs:
 
   - job: push
+    condition: not(contains(variables['Build.SourceVersionMessage'], 'from automated into main'))
 
     #
     # Push


### PR DESCRIPTION
Closes https://github.com/Azure/AzOps/issues/668

This PR contains a condition for the `push` pipeline.

Currently the push pipeline is triggered as soon as pull is finished, this has some concerns.

1. For the first push after the state is tracked in the repo, it will redeploy what `root` contains.
2. Since push is triggered from pull, changes happening during automatic scheduled crons will be redeployed.
3. It adds no "true value" besides actually ensuring that the JSON resource declarations works as expected. Many people tend to use these JSON resource declarations more for backup than for templates/deployments anyways.
4. It makes quite a large footprint and messy deployment history in the tenant, which can be quite unfortunate in certain cases.

Suggestion:

Add condition to ensure these scheduled pulls will still work and have the state in `root`, but not push it.

I have used this condition for some months in many repos with great success so I am very confident in this matter.

Orginial idea goes to @daltondhcp.