### PR TITLE
Update validate - deploy action for GitHub

### DIFF
--- a/.github/actions/validate-deploy/action.yml
+++ b/.github/actions/validate-deploy/action.yml
@@ -34,7 +34,7 @@ runs:
             }
           }
           else {
-            Write-Host '##[error]The validation pipeline failed because there is currently no change to be processed'
+            Write-Error -Message 'The validation pipeline failed because there is currently no change to be processed'
             exit 1
           }
       #


### PR DESCRIPTION
This PR changes the message behavior (GitHub) of an error message that appears as a visual error when nothing is wrong.

From: `Write-Host '##[error]The validation pipeline failed because there is currently no change to be processed'`

- When nothing is wrong:
 ![image](https://user-images.githubusercontent.com/64077181/190162594-9c2ef2d7-75ce-4438-b56e-9aaf8262e296.png)

- When something is wrong:
 ![image](https://user-images.githubusercontent.com/64077181/190164195-01968657-c2e2-45a4-8cb6-f2b4872cab9c.png)

To: `Write-Error -Message 'The validation pipeline failed because there is currently no change to be processed'`

- When nothing is wrong:
![image](https://user-images.githubusercontent.com/64077181/190162947-536e7733-391d-4add-afe8-7d8107c1022f.png)

- When something is wrong:
![image](https://user-images.githubusercontent.com/64077181/190162425-0dd29f36-5f6c-4b23-a2ec-4f47266390ed.png)

