### PR TITLE
Update validate results step - GitHub Action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,6 +79,7 @@ jobs:
       #
 
       - name: "Results"
+        if: always()
         shell: bash
         run: |
           if [ -f /tmp/OUTPUT.md ]; then


### PR DESCRIPTION
This PR changes the `Results` step behavior (in GitHub Action `validate.yml` workflow) to ensure results are posted back to pull request conversation if `validate-deploy` step fails (throws).

Relates to: https://github.com/Azure/AzOps/pull/687