### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/samples/oidc-azuread/pull.yml
+++ b/.github/samples/oidc-azuread/pull.yml
@@ -131,7 +131,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/samples/oidc-azuread/push.yml
+++ b/.github/samples/oidc-azuread/push.yml
@@ -45,7 +45,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/samples/oidc-azuread/validate.yml
+++ b/.github/samples/oidc-azuread/validate.yml
@@ -43,7 +43,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -138,7 +138,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,7 +56,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,7 +42,7 @@ jobs:
     #
 
     - name: "Checkout"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
     #
 
     - name: "Checkout"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         repository: 'Azure/AzOps-Accelerator'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,7 +49,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           


### PR DESCRIPTION
# Overview/Summary

This PR updates dependant checkout action from v2 to v3 to keep with the times [Node 12 out of support](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

Connected to [issue](https://github.com/Azure/AzOps/issues/696)

## This PR fixes/adds/changes/removes

1. Changes all workflows to `actions/checkout@v3` from `actions/checkout@v2`