### PR TITLE
Update to $GITHUB_OUTPUT

### DIFF
--- a/.github/samples/oidc-azuread/pull.yml
+++ b/.github/samples/oidc-azuread/pull.yml
@@ -207,9 +207,9 @@ jobs:
           echo $STATUS
           if [ -z "$STATUS" ]
           then
-            echo "::set-output name=state::stop"
+            echo "state=stop" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=state::continue"
+            echo "state=continue" >> $GITHUB_OUTPUT
           fi
 
       #

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -202,9 +202,9 @@ jobs:
           echo $STATUS
           if [ -z "$STATUS" ]
           then
-            echo "::set-output name=state::stop"
+            echo "state=stop" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=state::continue"
+            echo "state=continue" >> $GITHUB_OUTPUT
           fi
 
       #

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -104,7 +104,7 @@ jobs:
           git add .github/
           git commit -m 'Update commit'
           git push origin ${{ env.branch }} -f
-          echo "::set-output name=state::continue"
+          echo "state=continue" >> $GITHUB_OUTPUT
         fi
 
     #


### PR DESCRIPTION
# Overview/Summary

Update GitHub Actions from `set-output` to new `$GITHUB_OUTPUT`.

[Deprecating set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## This PR fixes/adds/changes/removes

1. changes `pull.yml`
2. changes `update.yml`

### Breaking Changes

N/A

## Testing Evidence

Tested logic update:

**Pull with no change test**
![image](https://user-images.githubusercontent.com/64077181/203255433-a139c5fc-650d-4cf8-9937-fa259b49a7a4.png)

**Pull with change test**
![image](https://user-images.githubusercontent.com/64077181/203255847-7417adc5-5f8f-452a-aa0a-33837016cbe6.png)
