### PR TITLE
Fix module latest version in pipeline cache

### DIFF
--- a/.github/actions/sharedSteps/action.yml
+++ b/.github/actions/sharedSteps/action.yml
@@ -11,8 +11,7 @@ runs:
       run: |
         $AzOpsModuleVersion = '${{env.AZOPS_MODULE_VERSION}}'
         if(-not $AzOpsModuleVersion) {
-          $latestVersionUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzOps'&`$filter=IsLatestVersion"
-          $latestVersionId = (Invoke-RestMethod $latestVersionUri).properties.NormalizedVersion
+          $latestVersionId = Find-Module AzOps | Select-Object -ExpandProperty Version
           echo "MODULE_VERSION=$latestVersionId" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
         }
         else {

--- a/.github/actions/sharedSteps/action.yml
+++ b/.github/actions/sharedSteps/action.yml
@@ -11,7 +11,7 @@ runs:
       run: |
         $AzOpsModuleVersion = '${{env.AZOPS_MODULE_VERSION}}'
         if(-not $AzOpsModuleVersion) {
-          $latestVersionId = Find-Module AzOps | Select-Object -ExpandProperty Version
+          $latestVersionId = Find-Module -Name AzOps | Select-Object -ExpandProperty Version
           echo "MODULE_VERSION=$latestVersionId" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
         }
         else {

--- a/.pipelines/.templates/sharedSteps.yml
+++ b/.pipelines/.templates/sharedSteps.yml
@@ -21,8 +21,7 @@ steps:
     inputs:
       targetType: "inline"
       script: |
-        $latestVersionUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzOps'&`$filter=IsLatestVersion"
-        $latestVersionId = (Invoke-RestMethod $latestVersionUri).properties.NormalizedVersion
+        $latestVersionId = Find-Module AzOps | Select-Object -ExpandProperty Version
         Write-Host "##vso[task.setvariable variable=AZOPS_MODULE_VERSION;]$latestVersionId"
 
   #

--- a/.pipelines/.templates/sharedSteps.yml
+++ b/.pipelines/.templates/sharedSteps.yml
@@ -21,7 +21,7 @@ steps:
     inputs:
       targetType: "inline"
       script: |
-        $latestVersionId = Find-Module AzOps | Select-Object -ExpandProperty Version
+        $latestVersionId = Find-Module -Name AzOps | Select-Object -ExpandProperty Version
         Write-Host "##vso[task.setvariable variable=AZOPS_MODULE_VERSION;]$latestVersionId"
 
   #


### PR DESCRIPTION
As discussed with @daltondhcp in private, due to an issue with the behaviour of the powershellgallery.com api it would be possible to make pipelines not run properly.
This PR resolves this issue by using `Find-Module` instead of the API to get the latest module version