### PR TITLE
Add condition for validate pipeline

### DIFF
--- a/.pipelines/validate.yml
+++ b/.pipelines/validate.yml
@@ -23,6 +23,7 @@ variables:
 jobs:
 
   - job: validate
+    condition: ne(variables['system.pullRequest.sourceBranch'], 'refs/heads/automated')
 
     #
     # Validate


### PR DESCRIPTION
This PR adds a condition to Azure DevOps `validate` pipeline to ensure that validate is skipped on branches created by automated pull.

Test case1: condition in place and automated pull runs and creates a branch with corresponding pull request
![testcase1](https://user-images.githubusercontent.com/64077181/206491920-30e4960a-3dde-4b5d-bc80-bbf33f35fd96.png)

Test case2: condition in place and any other branch has a pull request
![testcase2](https://user-images.githubusercontent.com/64077181/206493546-3e4877f8-3eaf-4887-b654-aca91730712a.png)
