### PR TITLE
Update Azure Pipelines for workload identity federation

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -135,7 +135,7 @@ jobs:
    
     #
     # Environment if using Federated Credentials 
-    # https://github.com/azure/azops/wiki/github-oidc
+    # https://github.com/azure/azops/wiki/oidc
     #
 
     # environment: prod 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,7 +59,7 @@ jobs:
 
     #
     # Environment if using Federated Credentials 
-    # https://github.com/azure/azops/wiki/github-oidc
+    # https://github.com/azure/azops/wiki/oidc
     #
 
     # environment: prod 

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -77,7 +77,7 @@ jobs:
 
     #
     # Environment if using Federated Credentials 
-    # https://github.com/azure/azops/wiki/github-oidc
+    # https://github.com/azure/azops/wiki/oidc
     #
 
     # environment: prod 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
         
     #
     # Environment if using Federated Credentials 
-    # https://github.com/azure/azops/wiki/github-oidc
+    # https://github.com/azure/azops/wiki/oidc
     #
 
     # environment: prod 

--- a/.pipelines/.templates/sharedSteps.yml
+++ b/.pipelines/.templates/sharedSteps.yml
@@ -63,6 +63,22 @@ steps:
         Save-Module @params
 
   #
+  # Federated Identity
+  # Get access token
+  #
+
+  - task: AzurePowerShell@5
+    displayName: "Access token"
+    condition: ne(variables['ARM_SERVICE_CONNECTION'], '')
+    inputs:
+      azureSubscription: $(ARM_SERVICE_CONNECTION)
+      pwsh: true
+      scriptType: 'InlineScript'
+      inline: |
+        $token = Get-AzAccessToken -ResourceTypeName MSGraph
+        Write-Host "##vso[task.setvariable variable=ARM_ACCESS_TOKEN;isSecret=true]$($token.Token)"
+
+  #
   # Connect
   # Authenticate Azure context
   # If no value is set for ARM_CLIENT_ID connect will try
@@ -73,6 +89,7 @@ steps:
     displayName: "Connect"
     env:
       ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+      ARM_ACCESS_TOKEN: $(ARM_ACCESS_TOKEN)
     inputs:
       targetType: "inline"
       script: |
@@ -84,8 +101,15 @@ steps:
         if ('$(ARM_ENVIRONMENT)' -in (Get-AzEnvironment).Name) {
           $azParams.Environment = '$(ARM_ENVIRONMENT)'
         }
+        # Use Service Principal if ARM_CLIENT_ID is set
         if('$(ARM_CLIENT_ID)') {
-          $azParams.credential = (New-Object PSCredential -ArgumentList '$(ARM_CLIENT_ID)', (ConvertTo-SecureString -String $Env:ARM_CLIENT_SECRET -AsPlainText -Force))
+          # Use federated credentials if token and no secret exists
+          if ($Env:ARM_ACCESS_TOKEN -and -not $Env:ARM_CLIENT_SECRET) {
+            $azParams.ApplicationId = '$(ARM_CLIENT_ID)'
+            $azParams.FederatedToken = '$Env:ARM_ACCESS_TOKEN' 
+          } else {
+            $azParams.credential = (New-Object PSCredential -ArgumentList '$(ARM_CLIENT_ID)', (ConvertTo-SecureString -String $Env:ARM_CLIENT_SECRET -AsPlainText -Force))
+          }
           Connect-AzAccount -ServicePrincipal @azParams
         } else {        
           Connect-AzAccount -Identity @azParams

--- a/.pipelines/.templates/sharedSteps.yml
+++ b/.pipelines/.templates/sharedSteps.yml
@@ -83,7 +83,7 @@ steps:
   # Connect
   # Authenticate Azure context
   # If no value is set for ARM_CLIENT_ID connect will try
-  # to use a Managed Identity. 
+  # to use a Managed Identity.
   #
 
   - task: PowerShell@2
@@ -94,7 +94,7 @@ steps:
     inputs:
       targetType: "inline"
       script: |
-        $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator  
+        $Env:PSModulePath = $Env:PSModulePath, '$(modulesFolder)' -join [IO.Path]::PathSeparator
         $azParams = @{
           SubscriptionId    = '$(ARM_SUBSCRIPTION_ID)'
           TenantId          = '$(ARM_TENANT_ID)'
@@ -103,15 +103,16 @@ steps:
           $azParams.Environment = '$(ARM_ENVIRONMENT)'
         }
         # Use Service Principal if ARM_CLIENT_ID is set
-        if('$(ARM_CLIENT_ID)') {
+        if($Env:ARM_CLIENT_ID -ne $null) {
           # Use federated credentials if token and no secret exists
-          if ($Env:ARM_ACCESS_TOKEN -and -not $Env:ARM_CLIENT_SECRET) {
+          # A U+200B ZERO WIDTH SPACE is inserted between dollar and parentheses to ensure literal comparison of ne and eq
+          if ($Env:ARM_ACCESS_TOKEN -ne '$​(ARM_ACCESS_TOKEN)' -and $Env:ARM_CLIENT_SECRET -eq '$​(ARM_CLIENT_SECRET)') {
             $azParams.ApplicationId = '$(ARM_CLIENT_ID)'
-            $azParams.FederatedToken = '$Env:ARM_ACCESS_TOKEN' 
+            $azParams.FederatedToken = '$Env:ARM_ACCESS_TOKEN'
           } else {
             $azParams.credential = (New-Object PSCredential -ArgumentList '$(ARM_CLIENT_ID)', (ConvertTo-SecureString -String $Env:ARM_CLIENT_SECRET -AsPlainText -Force))
           }
           Connect-AzAccount -ServicePrincipal @azParams
-        } else {        
+        } else {
           Connect-AzAccount -Identity @azParams
         }

--- a/.pipelines/.templates/sharedSteps.yml
+++ b/.pipelines/.templates/sharedSteps.yml
@@ -72,6 +72,7 @@ steps:
     condition: ne(variables['ARM_SERVICE_CONNECTION'], '')
     inputs:
       azureSubscription: $(ARM_SERVICE_CONNECTION)
+      azurePowerShellVersion: 'LatestVersion'
       pwsh: true
       scriptType: 'InlineScript'
       inline: |

--- a/.pipelines/.templates/vars.yml
+++ b/.pipelines/.templates/vars.yml
@@ -8,6 +8,10 @@ variables:
   # Set ARM_ENVIRONMENT to the Azure Environment you wish to use.
   # Valid values are: AzureCloud, AzureChinaCloud, AzureUSGovernment
   #
+  # Set ARM_SERVICE_CONNECTION to the name of the service connection
+  # that has been setup to use federated identity. In this case you also
+  # need to leave ARM_CLIENT_SECRET empty.
+  #
   # Set AZOPS_MODULE_VERSION to the desired version of the 
   # AzOps Module to enable version pinning. No value will cache the latest release.
   #
@@ -21,6 +25,7 @@ variables:
   # - ARM_CLIENT_ID
   # - ARM_CLIENT_SECRET
   # - ARM_ENVIRONMENT
+  # - ARM_SERVICE_CONNECTION
   # - AZOPS_MODULE_VERSION   
   # - AZOPS_CUSTOM_SORT_ORDER 
   #

--- a/.pipelines/.templates/vars.yml
+++ b/.pipelines/.templates/vars.yml
@@ -26,13 +26,13 @@ variables:
   # - ARM_CLIENT_SECRET
   # - ARM_ENVIRONMENT
   # - ARM_SERVICE_CONNECTION
-  # - AZOPS_MODULE_VERSION   
-  # - AZOPS_CUSTOM_SORT_ORDER 
+  # - AZOPS_MODULE_VERSION
+  # - AZOPS_CUSTOM_SORT_ORDER
   #
 
   - group: credentials
   - group: azops
-  
+
   #
   # modulesFolder
   # To enable caching of PowerShell modules between


### PR DESCRIPTION
Similar to the previous #133 which added support in GitHub Actions.

Here is the initial commit for Azure Pipelines - to utilise the new support for workload identity federation
https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/2022/secret-free-deployments
Currently in preview but expected GA before the end of the year.

Validation done:
Validated that all pipelines work with and without secrets / federated credentials. Not tested with Managed Identities.