### PR TITLE
Update GitHub Actions Checkout from v3 to v4

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -154,7 +154,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,7 +72,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -90,7 +90,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,7 +42,7 @@ jobs:
     #
 
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
     #
 
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         repository: 'Azure/AzOps-Accelerator'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,7 +66,7 @@ jobs:
       #
 
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           


### PR DESCRIPTION
This PR updates the usage of `actions/checkout@v3` to `actions/checkout@v4` in `pull.yml`, `push.yml`, `redeploy.yml`, `update.yml` and `validate.yml`.

The shift of version has been tested for pull, push and validate.