### PR TITLE
Adding Core.AllowMultipleTemplateParameterFiles and Core.MultipleTemplateParameterFileSuffix

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -41,6 +41,7 @@
             "Core.SubscriptionsToIncludeResourceGroups": ["*"],
             "Core.TemplateParameterFileSuffix": ".json",
             "Core.AllowMultipleTemplateParameterFiles": false,
+            "Core.DeployAllMultipleTemplateParameterFiles": false,
             "Core.MultipleTemplateParameterFileSuffix": ".x",
             "Core.ThrottleLimit": 5,
             "Core.WhatifExcludedChangeTypes":[

--- a/settings.json
+++ b/settings.json
@@ -40,6 +40,8 @@
             "Core.SkipRole": false,
             "Core.SubscriptionsToIncludeResourceGroups": ["*"],
             "Core.TemplateParameterFileSuffix": ".json",
+            "Core.AllowMultipleTemplateParameterFiles": false,
+            "Core.MultipleTemplateParameterFileSuffix": ".x",
             "Core.ThrottleLimit": 5,
             "Core.WhatifExcludedChangeTypes":[
                 "NoChange",


### PR DESCRIPTION
This PR is to align new possible setting `Core.AllowMultipleTemplateParameterFiles: false`, `DeployAllMultipleTemplateParameterFiles: false` and `Core.MultipleTemplateParameterFileSuffix: ".x"` to support [Adding Support for Single Template with Multiple Parameter Files](https://github.com/Azure/AzOps/pull/836)