### PR TITLE
Adding Core.ParallelDeployMultipleTemplateParameterFiles

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -43,6 +43,7 @@
             "Core.AllowMultipleTemplateParameterFiles": false,
             "Core.DeployAllMultipleTemplateParameterFiles": false,
             "Core.MultipleTemplateParameterFileSuffix": ".x",
+            "Core.ParallelDeployMultipleTemplateParameterFiles": false,
             "Core.ThrottleLimit": 5,
             "Core.WhatifExcludedChangeTypes":[
                 "NoChange",


### PR DESCRIPTION
This PR is to align new possible setting `Core.ParallelDeployMultipleTemplateParameterFiles: false` to support [Adding Support for Parallel Deployments with Multiple Parameter Files](https://github.com/Azure/AzOps/pull/842)