### PR TITLE
Adding Core.SubscriptionsToIncludeChildResource

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -40,6 +40,7 @@
                 "Microsoft.VSOnline/plans"
             ],
             "Core.SkipRole": false,
+            "Core.SubscriptionsToIncludeChildResource": ["*"],
             "Core.SubscriptionsToIncludeResourceGroups": ["*"],
             "Core.TemplateParameterFileSuffix": ".json",
             "Core.AllowMultipleTemplateParameterFiles": false,


### PR DESCRIPTION
This PR is to align setting `Core.SubscriptionsToIncludeChildResource` to support https://github.com/Azure/AzOps/pull/880